### PR TITLE
Update concrete class to implement the Element interface

### DIFF
--- a/visitor/demo.ts
+++ b/visitor/demo.ts
@@ -5,8 +5,8 @@ namespace VisitorPattern {
 		export function show() : void {
 		    var objs: VisitorPattern.Objs = new VisitorPattern.Objs();
 
-			objs.attach(<VisitorPattern.Element> new VisitorPattern.ConcreteElement1());
-			objs.attach(<VisitorPattern.Element> new VisitorPattern.ConcreteElement2());
+			objs.attach(new VisitorPattern.ConcreteElement1());
+			objs.attach(new VisitorPattern.ConcreteElement2());
 
 			var v1: VisitorPattern.ConcreteVisitor1 = new VisitorPattern.ConcreteVisitor1(),
 				v2: VisitorPattern.ConcreteVisitor2 = new VisitorPattern.ConcreteVisitor2();

--- a/visitor/visitor.ts
+++ b/visitor/visitor.ts
@@ -29,14 +29,14 @@ namespace VisitorPattern {
         operate(visitor: Visitor): void;
     }
 
-    export class ConcreteElement1 {
+    export class ConcreteElement1 implements Element {
         public operate(visitor: Visitor): void {
             console.log("`operate` of ConcreteElement1 is being called!");
             visitor.visitConcreteElement1(this);
         }
     }
 
-    export class ConcreteElement2 {
+    export class ConcreteElement2 implements Element {
         public operate(visitor: Visitor): void {
             console.log("`operate` of ConcreteElement2 is being called!");
             visitor.visitConcreteElement2(this);


### PR DESCRIPTION
Update concrete class to implement the Element interface.So that in `demo.ts` no need to cast from Concrete Element to Element type.