### PR TITLE
factoryMethod: add a more TypeScript-y Factory fn

### DIFF
--- a/factory_method/factoryMethod.ts
+++ b/factory_method/factoryMethod.ts
@@ -17,8 +17,8 @@ namespace FactoryMethodPattern {
     }
 
 
-    export class ProductFactory {
-        public static createProduct(type: string) : AbstractProduct {
+    export namespace ProductFactory {
+        export function createProduct(type: string) : AbstractProduct {
             if (type === "A") {
                 return new ConcreteProductA();
             } else if (type === "B") {


### PR DESCRIPTION
Creating a class to only add a static method will generate a prototype with a function directly added to it, when it could generate directly the object with the function added as a property.

This does not change any calling interface, only affects the generated code.